### PR TITLE
Fix "error: command not found" bug and make "No instances found" message better

### DIFF
--- a/bin/ssmc
+++ b/bin/ssmc
@@ -46,16 +46,16 @@ OPTIONS
 EOF
 }
 
-msg() {
+error() {
   printf '%s\n' "$*" >&2
 }
 
 verbose() {
-  [ -n "$verbose" ] && msg "$@"
+  [ -n "$verbose" ] && error "$@"
 }
 
 error_exit() {
-  msg "$@"
+  error "$@"
   exit 1
 }
 
@@ -181,6 +181,6 @@ session_cmd=(aws ssm start-session --target "$instance_id")
 [ -n "$profile" ] && session_cmd+=(--profile "$profile")
 [ -n "$region" ] && session_cmd+=(--region "$region")
 
-msg "Connecting to ${chosen_parts[*]:3} (${instance_id} in ${region})"
+error "Connecting to ${chosen_parts[*]:3} (${instance_id} in ${region})"
 verbose "${session_cmd[@]}"
 exec "${session_cmd[@]}"


### PR DESCRIPTION
- Fixed missing `error` function (e.g. in [line 102](https://github.com/justinhoward/misc-scripts/blob/master/bin/ssmc#L102)) by replacing all occurrences of `msg` with `error` (because it has the same semantics)