### PR TITLE
Use PR Branch Name to find JIRA ticket

### DIFF
--- a/bin/rngen
+++ b/bin/rngen
@@ -248,8 +248,9 @@ for line in "${changelog_json[@]}"; do
   number="$(echo "$line" | jq -r .number)"
   user="$(echo "$line" | jq -r .user.login)"
   body="$(echo "$line" | jq -r .body)"
+  head_branch="$(echo "$line" | jq -r .head.ref)"
   gh_url="$(echo "$line" | jq -r .html_url)"
-  jira_issue="$(echo "$title $body" | grep -oE '[A-Z]{2,8}-[0-9]{1,6}' | head -1)"
+  jira_issue="$(echo "$title $body $head_branch" | grep -oE '[A-Z]{2,8}-[0-9]{1,6}' | head -1)"
   if [ -n "$jira_issue" ]; then
     jira_issues+=("$jira_issue")
     set -o pipefail


### PR DESCRIPTION
If the title and body do not contain a JIRA ticket, look at the `head.ref` (branch merged in the PR) to find a ticket.