### PR TITLE
Add release comment to jira ticket before closing

### DIFF
--- a/bin/rngen
+++ b/bin/rngen
@@ -159,6 +159,14 @@ jira_close() {
   fi
 }
 
+jira_comment() {
+  if ! command -v jira >/dev/null 2>&1; then
+    jira-terminal comment --body "$2" --ticket "$1" > /dev/null
+  else
+    jira issue comment add "$1" "$2" --no-input > /dev/null
+  fi
+}
+
 if ! command -v gh-changelog > /dev/null; then
   error_exit 'gh-changelog is required https://github.com/justinhoward/misc-scripts/blob/master/bin/gh-changelog'
 fi
@@ -359,6 +367,7 @@ if [ "${#changelog_list[@]}" -gt 0 ] || [ -n "$force_deploy" ]; then
     printf '%s `%s`\n\n' "$repo_name" "$tag_name"
   elif [ -n "$previous_release" ]; then
     # shellcheck disable=2016
+    tag_name="$latest"
     printf '%s `%s`\n\n' "$repo_name" "$latest"
   fi
 
@@ -397,6 +406,9 @@ fi
 
 if [ -n "$close_jira" ]; then
   for issue in "${jira_issues[@]}"; do
+  jira_issues_unique=$(printf "%s\n" "${jira_issues[@]}" | sort -u)
+  for issue in "${jira_issues_unique[@]}"; do
+    jira_comment "$issue" "Release: $repo_name $tag_name"
     jira_close "$issue" && msg "Closed $issue"
   done
 fi


### PR DESCRIPTION
I have this as part of the iOS release scripts - to auto add a comment to the jira ticket with the release version and then close the ticket. This is helpful to track which release the change was part of. I thought it might be useful for other projects too.