### PR TITLE
Add port-forwarding support to ssmc

### DIFF
--- a/bin/ssmc
+++ b/bin/ssmc
@@ -33,6 +33,8 @@ $(color 2 "-f|--filters") FILTERS          A filter for the native aws ec2 comma
                                 The format is "Name=<filter>,Values=<value>,<value>"
                                 Allows multiple instances of -f.
                                 See "aws ec2 describe-instances help" for a full list.
+$(color 2 "-F|--port-forward") LP:RH:RP    Enable port forwarding with format:
+                                           local-port:remote-host:remote-port
 $(color 2 "-h|--help")                     Show this help message
 $(color 2 "-i|--instance-id") INSTANCE_ID  Connect to INSTANCE_ID directly
 $(color 2 "-l|--list")                     Force printing the list even for only 1 option
@@ -117,8 +119,8 @@ print_run() {
   "$@"
 }
 
-shortopts='c:f:hi:lnp:r:Rs:t:v'
-longopts='columns:,filters:,help,instance-id:,list,dry-run,profile:,region:,all-regions,select:,tags:,verbose'
+shortopts='c:f:F:hi:lnp:r:Rs:t:v'
+longopts='columns:,filters:,port-forward:,help,instance-id:,list,dry-run,profile:,region:,all-regions,select:,tags:,verbose'
 
 if ! getopt -T > /dev/null; then
   options="$(getopt \
@@ -140,6 +142,7 @@ while true; do
   case "$1" in
     -c|--columns) columns="$2"; shift 2 ;;
     -f|--filters) filters+=("$2"); shift 2 ;;
+    -F|--port-forward) port_forward="$2"; shift 2 ;;
     -h|--help) usage 1 && exit ;;
     -i|--instance-id) provided_instance_id="$2"; shift 2 ;;
     -l|--list) list=1; shift ;;
@@ -165,6 +168,14 @@ fi
 if ! command -v session-manager-plugin >/dev/null; then
   error 'The AWS session-manager-plugin is required'
   error_exit 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
+fi
+
+if [ -n "$port_forward" ]; then
+  if ! [[ "$port_forward" =~ ^[0-9]+:[^:]+:[0-9]+$ ]]; then
+    error_exit "Invalid port forward argument ${port_forward}"
+  fi
+
+  IFS=':' read -r local_port remote_host remote_port <<< "$port_forward"
 fi
 
 [ -z "$columns" ] && columns=name
@@ -244,6 +255,10 @@ fi
 session_cmd=(aws ssm start-session --target "$instance_id")
 [ -n "$profile" ] && session_cmd+=(--profile "$profile")
 [ -n "$region" ] && session_cmd+=(--region "$region")
+[ -n "$local_port" ] && session_cmd+=(
+  --document-name "AWS-StartPortForwardingSessionToRemoteHost"
+  --parameters "{\"portNumber\":[\"$remote_port\"], \"localPortNumber\":[\"$local_port\"], \"host\":[\"$remote_host\"]}"
+)
 
 msg "Connecting to $(color 2 "${chosen_parts[*]:3}") ($(color 4 "${instance_id}") in $(color 4 "${region}"))" ''
 verbose "${session_cmd[@]}"


### PR DESCRIPTION
New port-forward option composition: <local-port>:<remote-host>:<remote-port>.

Example:
```
$ ssmc -F 33060:parentsquare-db.staging.parentsquare.com:3306 -p ps-staging-ssm parentsquare-staging-utility 
Connecting to parentsquare-staging-utility (i-0f62d2d4f872d0aae in us-east-1) 

Starting session with SessionId: elliot.barlas@parentsquare.com-b3nkcfdvq32nr869i88ztd58uq
Port 33060 opened for sessionId elliot.barlas@parentsquare.com-b3nkcfdvq32nr869i88ztd58uq.
Waiting for connections...
```

Invalid CLi arg:
```
$ ssmc -F 33060:parentsquare-db.staging.parentsquare.com -p ps-staging-ssm parentsquare-staging-utility 
Invalid port forward argument 33060:parentsquare-db.staging.parentsquare.com
```